### PR TITLE
Set default value on enum's second type param

### DIFF
--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -52,7 +52,7 @@ export class ZodEnum<T extends [string, ...string[]]> extends z.ZodType<T[number
     return enumValues as any;
   }
 
-  static create = <U extends string, T extends [U, ...U[]]>(values: T): ZodEnum<T> => {
+  static create = <U extends string, T extends [U, ...U[]] = [U, ...U[]]>(values: T): ZodEnum<T> => {
     return new ZodEnum({
       t: z.ZodTypes.enum,
       values: values,


### PR DESCRIPTION
The second type param on the enum type has a sensible default value so that it's possible to explicitly set the value type without having to duplicate this in the second parameter.